### PR TITLE
Implement `FileCache` and integrate in schematic scene

### DIFF
--- a/revedaEditor/common/fileCache.py
+++ b/revedaEditor/common/fileCache.py
@@ -1,0 +1,90 @@
+#    "Commons Clause" License Condition v1.0
+#   #
+#    The Software is provided to you by the Licensor under the License, as defined
+#    below, subject to the following condition.
+#
+#    Without limiting other conditions in the License, the grant of rights under the
+#    License will not include, and the License does not grant to you, the right to
+#    Sell the Software.
+#
+#    For purposes of the foregoing, "Sell" means practicing any or all of the rights
+#    granted to you under the License to provide to third parties, for a fee or other
+#    consideration (including without limitation fees for hosting) a product or service whose value
+#    derives, entirely or substantially, from the functionality of the Software. Any
+#    license notice or attribution required by the License must also include this
+#    Commons Clause License Condition notice.
+#
+#   Add-ons and extensions developed for this software may be distributed
+#   under their own separate licenses.
+#
+#    Software: Revolution EDA
+#    License: Mozilla Public License 2.0
+#    Licensor: Revolution Semiconductor (Registered in the Netherlands)
+#
+
+"""File content caching with modification-time invalidation."""
+
+import logging
+import os
+import pathlib
+from typing import Any, Optional
+
+import orjson
+
+logger = logging.getLogger(__name__)
+
+
+class FileCache:
+    """Singleton file content cache with mtime-based invalidation."""
+
+    _instance: Optional["FileCache"] = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._cache: dict[str, tuple[float, Any]] = {}
+            cls._instance._max_size = 256
+        return cls._instance
+
+    def get_json(self, file_path: str | pathlib.Path) -> Optional[Any]:
+        """Load and cache JSON file contents, invalidating on mtime change."""
+        path_str = str(file_path)
+
+        try:
+            mtime = os.path.getmtime(path_str)
+        except OSError:
+            self._cache.pop(path_str, None)
+            return None
+
+        cached = self._cache.get(path_str)
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
+
+        try:
+            with open(path_str, "rb") as f:
+                content = orjson.loads(f.read())
+        except (orjson.JSONDecodeError, OSError) as e:
+            logger.debug(f"Failed to load {path_str}: {e}")
+            self._cache.pop(path_str, None)
+            return None
+
+        if len(self._cache) >= self._max_size:
+            to_remove = list(self._cache.keys())[:self._max_size // 4]
+            for key in to_remove:
+                del self._cache[key]
+
+        self._cache[path_str] = (mtime, content)
+        return content
+
+    def invalidate(self, file_path: str | pathlib.Path) -> None:
+        """Remove a specific file from the cache."""
+        self._cache.pop(str(file_path), None)
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._cache.clear()
+
+    @property
+    def size(self) -> int:
+        """Return number of cached entries."""
+        return len(self._cache)

--- a/revedaEditor/scenes/schematicScene.py
+++ b/revedaEditor/scenes/schematicScene.py
@@ -51,6 +51,7 @@ import revedaEditor.gui.alignItems as alg
 import revedaEditor.gui.fileDialogues as fd
 import revedaEditor.gui.propertyDialogues as pdlg
 from revedaEditor.backend.pdkLoader import importPDKModule
+from revedaEditor.common.fileCache import FileCache
 from revedaEditor.scenes.editorScene import editorScene
 
 schlyr = importPDKModule('schLayers')
@@ -135,7 +136,7 @@ class schematicScene(editorScene):
         self.alignLineFinished.connect(alg.alignToLine)
 
         # Initialize cache
-        self._symbolCache = {}
+        self._symbolCache = FileCache()
 
     def _initializeFont(self):
         """Initialize fixed-width font settings."""
@@ -489,9 +490,8 @@ class schematicScene(editorScene):
         if self._newNet:
             snapPoints.update(self.findNetInterSect(self._newNet, snapRect))
         if snapPoints:
-            lengths = [(snapPoint - eventLoc).manhattanLength() for snapPoint in
-                       snapPoints]
-            closestPoint = list(snapPoints)[lengths.index(min(lengths))]
+            closestPoint = min(snapPoints,
+                               key=lambda p: (p - eventLoc).manhattanLength())
             return closestPoint
         else:
             return eventLoc
@@ -501,10 +501,11 @@ class schematicScene(editorScene):
         snapPoints = set()
         rectItems = set(self.items(sceneRect)) - ignoredSet
         for item in rectItems:
-            if isinstance(item, snet.schematicNet) and any(
-                    list(map(sceneRect.contains, item.sceneEndPoints))):
-                snapPoints.add(item.sceneEndPoints[list(
-                    map(sceneRect.contains, item.sceneEndPoints)).index(True)])
+            if isinstance(item, snet.schematicNet):
+                for ep in item.sceneEndPoints:
+                    if sceneRect.contains(ep):
+                        snapPoints.add(ep)
+                        break
             elif isinstance(item, shp.symbolPin):
                 snapPoints.add(item.mapToScene(item.start).toPoint())
             elif isinstance(item, shp.schematicPin):
@@ -564,11 +565,11 @@ class schematicScene(editorScene):
         orderedPoints = [currentPoint]
 
         while points:
-            distances = [(point - currentPoint).manhattanLength() for point in
-                         points]
-            nearest_point_index = distances.index(min(distances))
-            nearestPoint = points[nearest_point_index]
-            orderedPoints.append(nearestPoint)
+            nearest_point_index = min(
+                range(len(points)),
+                key=lambda i: (points[i] - currentPoint).manhattanLength()
+            )
+            orderedPoints.append(points[nearest_point_index])
             currentPoint = points.pop(nearest_point_index)
 
         return orderedPoints
@@ -719,12 +720,11 @@ class schematicScene(editorScene):
                                      instanceTuple.viewName, )
         viewPath = viewItem.viewPath
         try:
-            # Try to get items from cache first
-            items = self._symbolCache.get(viewPath)
+            # Use FileCache with mtime invalidation
+            items = self._symbolCache.get_json(viewPath)
             if items is None:
-                with open(viewPath, "r") as temp:
-                    items = json.load(temp)
-                    self._symbolCache[viewPath] = items
+                self.logger.error(f"Cannot load symbol file: {viewPath}")
+                return
 
             # Use comprehensions for better performance
             itemAttributes = {item["nam"]: item["def"] for item in items[2:] if


### PR DESCRIPTION
This PR introduces a modification-time-aware file caching utility to handle symbol files dynamically and optimizes several point-calculation functions.

* **Added `FileCache`:** Introduced a new singleton class in `revedaEditor/common/fileCache.py` with FIFO eviction and modification-time-based invalidation for parsed file contents.
* **Refactored Symbol Loading:** Updated `schematicScene.py` to use `FileCache` instead of a static dictionary cache, ensuring symbol files automatically reload when changed on disk.
* **Optimized Point Logic:** * Simplified both `findSnapPoint` and `orderPoints` by utilizing `min()` with a key function for cleaner nearest-point resolution.
* Streamlined `findConnectPoints` with early-exit iteration for improved readability and efficiency.